### PR TITLE
Refactor imapsync and cron handling

### DIFF
--- a/imageroot/actions/create-task/20configure
+++ b/imageroot/actions/create-task/20configure
@@ -54,22 +54,10 @@ if data.get("exclude",'') == "":
 else:
     exclude = ","+ data.get("exclude",'')
 
-# cron
+# Cron is expanded before the service start
 cron = data.get("cron","")
-if cron != "":
-    if 'h' in cron:
-        cron_env = "1 */"+cron.replace('h','')+" * * *  root /usr/local/bin/syncctl start "+localuser+'_'+task_id
-    elif 'm' in cron:
-        cron_env = "*/"+cron.replace('m','')+" * * * * root /usr/local/bin/syncctl start "+localuser+'_'+task_id
-    f = open("./cron/"+localuser+'_'+task_id+".cron", "w", encoding="utf-8")
-    # MAIL_HOST is an env variable used by perl/imapsync 
-    f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
-    f.write(cron_env+"\n")
-    f.close()
-# cron does not exist we remove or ignore
-elif cron == "" and os.path.exists("./cron/"+localuser+'_'+task_id+".cron"):
-    os.remove("./cron/"+localuser+'_'+task_id+".cron")
 
+# folder synchronization
 foldersynchronization = data.get("foldersynchronization","all")
 if foldersynchronization == "inbox":
     folder_inbox = "--folder\ 'INBOX'"

--- a/imageroot/actions/import-module/40migration
+++ b/imageroot/actions/import-module/40migration
@@ -132,7 +132,7 @@ EXPUNGE_REMOTE={expunge_remote}
 CRON={cron}
 FOLDER_INBOX={folder_inbox}
 FOLDERSYNCHRONIZATION={foldersynchronization}
-    """
+"""
     os.umask(0o77)
 
     f = open("./imapsync/"+localuser+'_'+task_id+".env", "w", encoding="utf-8")

--- a/imageroot/actions/import-module/40migration
+++ b/imageroot/actions/import-module/40migration
@@ -100,19 +100,12 @@ for properties in getmail_properties:
     # not available in getmail, we disable for validation
     exclude = ""
 
-    # cron
+    # Cron is expanded before the service start
     if cron != "":
         if cron == '60':
-            cron_env = "1 */1 * * *  root /usr/local/bin/syncctl start "+localuser+'_'+task_id
             cron = '1h'
         else:
-            cron_env = "*/"+cron+" * * * * root /usr/local/bin/syncctl start "+localuser+'_'+task_id
             cron = cron + 'm'
-        f = open("./cron/"+localuser+'_'+task_id+".cron", "w", encoding="utf-8")
-        # # MAIL_HOST is an env variable used by perl/imapsync 
-        # f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
-        f.write(cron_env+"\n")
-        f.close()
 
     foldersynchronization = "inbox"
     folder_inbox = "--folder\ 'INBOX'"

--- a/imageroot/actions/import-module/40migration
+++ b/imageroot/actions/import-module/40migration
@@ -109,8 +109,8 @@ for properties in getmail_properties:
             cron_env = "*/"+cron+" * * * * root /usr/local/bin/syncctl start "+localuser+'_'+task_id
             cron = cron + 'm'
         f = open("./cron/"+localuser+'_'+task_id+".cron", "w", encoding="utf-8")
-        # MAIL_HOST is an env variable used by perl/imapsync 
-        f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
+        # # MAIL_HOST is an env variable used by perl/imapsync 
+        # f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
         f.write(cron_env+"\n")
         f.close()
 

--- a/imageroot/actions/import-module/40migration
+++ b/imageroot/actions/import-module/40migration
@@ -10,6 +10,10 @@ import uuid
 import os
 import sys
 
+# create directories
+os.makedirs('imapsync', exist_ok=True)
+os.makedirs('cron', exist_ok=True)
+
 file_path = './getmail.json'
 
 with open(file_path, 'r') as file:

--- a/imageroot/bin/expand-cron
+++ b/imageroot/bin/expand-cron
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+
+# This script expands cron tasks based on environment files.
+# It reads environment files in the 'imapsync' directory, extracts relevant information,
+# and generates corresponding cron files in the 'cron' directory.
+
+
+
+import agent
+import glob
+import os
+
+for file in glob.iglob("cron/*.cron"):
+    os.remove(file)
+
+env_files = list(glob.iglob("imapsync/*.env"))
+for task_id in env_files:
+    task_id = task_id.removesuffix('.env').removeprefix('imapsync/')
+    data = agent.read_envfile('imapsync/'+task_id+'.env')
+    if data['CRON'] != '':
+        if '1h' in data['CRON']:
+            cron_env = "1 */"+data['CRON'].replace('h','')+" * * *  root /usr/local/bin/syncctl start "+data['LOCALUSER']+'_'+data['TASK_ID']
+        elif 'm' in data['CRON']:
+            cron_env = "*/"+data['CRON'].replace('m','')+" * * * * root /usr/local/bin/syncctl start "+data['LOCALUSER']+'_'+data['TASK_ID']
+        f = open("./cron/"+data['LOCALUSER']+'_'+data['TASK_ID']+".cron", "w", encoding="utf-8")
+        # MAIL_HOST is an env variable used by perl/imapsync
+        # env of the cron !== env of the service
+        f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
+        f.write(cron_env+"\n")
+        f.close()

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -21,6 +21,6 @@ if event['module_uuid'] == os.getenv('MAIL_SERVER', ''):
    providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
       'module_uuid': mail_server,
    })
-   mail_host = providers[0]["mail_host"]
+   mail_host = providers[0]["host"]
    agent.set_env("MAIL_HOST",mail_host)
    agent.run_helper("systemctl", "--user", "try-restart", "imapsync.service").check_returncode()

--- a/imageroot/systemd/user/imapsync.service
+++ b/imageroot/systemd/user/imapsync.service
@@ -22,6 +22,7 @@ ExecStartPre=/bin/rm -f %t/imapsync.pid %t/imapsync.ctr-id
 ExecStartPre=mkdir -vp %S/state/imapsync
 ExecStartPre=mkdir -vp %S/state/cron
 ExecStartPre=runagent reveal-master-secret
+ExecStartPre=runagent expand-cron
 ExecStart=/usr/bin/podman run \
     --detach \
     --conmon-pidfile=%t/imapsync.pid \


### PR DESCRIPTION
This pull request includes several changes to improve the imapsync and cron handling in the codebase. The commits in this pull request are as follows:

1. Create directories for imapsync and cron

2. Fix cron job file writing

3. Remove unnecessary whitespace in import-module script

4. Refactor cron handling in create-task and import-module actions

5. Fix mail host key in mail-settings-changed event

These changes aim to enhance the functionality and efficiency of the imapsync and cron processes. They also address specific issues and improve the overall code quality.

Please review the changes and provide any feedback or suggestions. Thank you.

Fixes #4520


Well above is generated by copilot, lets me say it with my word


The change is done because I need to write the MAIL_HOST in cron, the env cron is not the same that the env service, now with that fix when the mail module will be changed we will restart the service and accordingly modify the MAIL_HOST for all cron job

this PR is is tied to https://github.com/NethServer/dev/issues/6776

