### PR TITLE
Fix cron task creation in create-task script

### DIFF
--- a/imageroot/actions/create-task/20configure
+++ b/imageroot/actions/create-task/20configure
@@ -54,8 +54,21 @@ if data.get("exclude",'') == "":
 else:
     exclude = ","+ data.get("exclude",'')
 
-# Cron is expanded before the service start
+# Cron is expanded before the service start but manually each cron task is created now
 cron = data.get("cron","")
+if cron != "":
+    if 'h' in cron:
+        cron_env = "1 */"+cron.replace('h','')+" * * *  root /usr/local/bin/syncctl start "+localuser+'_'+task_id
+    elif 'm' in cron:
+        cron_env = "*/"+cron.replace('m','')+" * * * * root /usr/local/bin/syncctl start "+localuser+'_'+task_id
+    f = open("./cron/"+localuser+'_'+task_id+".cron", "w", encoding="utf-8")
+    # MAIL_HOST is an env variable used by perl/imapsync 
+    f.write('MAIL_HOST='+os.environ['MAIL_HOST']+"\n")
+    f.write(cron_env+"\n")
+    f.close()
+# cron does not exist we remove or ignore
+elif cron == "" and os.path.exists("./cron/"+localuser+'_'+task_id+".cron"):
+    os.remove("./cron/"+localuser+'_'+task_id+".cron")
 
 # folder synchronization
 foldersynchronization = data.get("foldersynchronization","all")


### PR DESCRIPTION
This pull request fixes the issue with cron task creation in the create-task script. Previously, the cron tasks were not being created correctly, leading to synchronization problems. This PR updates the script to properly create the cron tasks based on the provided cron schedule. Additionally, it handles the case where the cron schedule is empty, removing any existing cron task files if necessary.

When we create a task, we do not restart the container itself, we need to handle to create the cron file or handle to remove it

https://github.com/NethServer/dev/issues/6776