### PR TITLE
Fix validation error messages and translations

### DIFF
--- a/imageroot/actions/create-task/30Imapsync_validation
+++ b/imageroot/actions/create-task/30Imapsync_validation
@@ -26,6 +26,10 @@ elif 'SSL connect attempt failed' in result.stdout:
     agent.set_status('validation-failed')
     json.dump([{'field':'createTask','parameter':'createTask','value':'SSL_encryption_error','error':'SSL_encryption_error'}],fp=sys.stdout, default=str)
     sys.exit(4)
+elif 'ERR_EXIT_TLS_FAILURE' in result.stdout:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'createTask','parameter':'createTask','value':'STARTTLS_not_allowed_use_IMAPS','error':'STARTTLS_not_allowed_use_IMAPS'}],fp=sys.stdout, default=str)
+    sys.exit(4)
 elif 'ERR_CONNECTION_FAILURE_HOST1' in result.stdout:
     agent.set_status('validation-failed')
     json.dump([{'field':'createTask','parameter':'createTask','value':'Check_hostname_or_tcp_port','error':'Check_hostname_or_tcp_port'}],fp=sys.stdout, default=str)

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -92,7 +92,7 @@
     "delete_on_remote":"Delete messages on remote once synchronized",
     "bad_user_credentials": "Verify the user credentials, the remote server refused to authenticate",
     "Check_hostname_or_tcp_port": "Verify the Hostname and the TCP port, the remote server refused to authenticate",
-    "SSL_encryption_error":"Verify the TLS encryption, IMAPS of STARTTLS",
+    "SSL_encryption_error":"Verify the TLS encryption, IMAPS or STARTTLS",
     "localuser_string_gte": "The local username cannot be empty",
     "synchronize_folders": "Folder synchronization",
     "synchronize_folders_explanation": "You can decide to make a full synchronization, only INBOX, or folders exclusion",
@@ -111,8 +111,8 @@
     "informations": "Informations",
     "fetching_statistic_please_wait":"Waiting to retrieve statictics, please wait",
     "every_minutes":"Every {num} minutes",
-    "configure_imapsync": "Go to the settings"
-
+    "configure_imapsync": "Go to the settings",
+    "STARTTLS_not_allowed_use_IMAPS": "STARTTLS is not allowed by the provider"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request fixes validation error messages and translations in the codebase. Specifically, it addresses the following issues:

- Updated the error message for SSL encryption error to include both IMAPS and STARTTLS options.

- Added a new error message for when STARTTLS is not allowed and IMAPS should be used instead.

These changes improve the clarity and accuracy of the error messages, making it easier for users to understand and troubleshoot any validation errors they encounter.


https://github.com/NethServer/dev/issues/6776