### PR TITLE
Update mail_host format and add pattern validation

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -19,7 +19,8 @@
         "mail_host": {
             "type": "string",
             "description": "Host name for the remote account",
-            "format": "idn-hostname",
+            "format": "hostname",
+            "pattern": "\\.",
             "title": "mail_host"
         },
         "mail_server": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -31,7 +31,9 @@
     "instance_configuration": "Configure Imapsync",
     "choose_mail_server": "Select a domain",
     "choose_the_mail_server_to_use": "Choose the mail server from which to retrieve users mailboxes",
-    "mail_server_is_not_valid": "This mail server is not valid"
+    "mail_server_is_not_valid": "This mail server is not valid",
+    "mail_host_pattern": "Must be a valid fully qualified domain name",
+    "mail_host_format": "Must be a valid fully qualified domain name"
   },
   "tasks": {
     "no_tasks": "No tasks configured",


### PR DESCRIPTION
This pull request updates the format validation for the `mail_host` field in the `validate-input.json` file. It now uses the `hostname` format and adds a pattern validation to ensure it is a valid fully qualified domain name. Additionally, it adds validation messages for the error in the `translation.json` file.

https://github.com/NethServer/dev/issues/6853