### PR TITLE
Remove unnecessary imapsync test

### DIFF
--- a/tests/imapsync.robot
+++ b/tests/imapsync.robot
@@ -9,16 +9,6 @@ Check if imapsync is installed correctly
     &{output} =    Evaluate    ${output}
     Set Suite Variable    ${module_id}    ${output.module_id}
 
-Check if imapsync can be configured
-    ${rc} =    Execute Command    api-cli run module/${module_id}/configure-module --data '{}'
-    ...    return_rc=True  return_stdout=False
-    Should Be Equal As Integers    ${rc}  0
-
-Check if imapsync works as expected
-    ${rc} =    Execute Command    curl -f http://127.0.0.1/imapsync/
-    ...    return_rc=True  return_stdout=False
-    Should Be Equal As Integers    ${rc}  0
-
 Check if imapsync is removed correctly
     ${rc} =    Execute Command    remove-module --no-preserve ${module_id}
     ...    return_rc=True  return_stdout=False


### PR DESCRIPTION
The imapsync test for checking if it can be configured and works as expected has been removed as it is no longer usable without a mail server.