### PR TITLE
Fix sourcing of env variable

### DIFF
--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -22,7 +22,14 @@ fi
 action=${1}
 task_id=${2}
 
-source /etc/imapsync/${task_id}.env
+while IFS= read -r line; do
+  # Trim leading/trailing whitespace
+  line=$(echo "$line" | xargs)
+  # Ignore empty lines
+  [ -z "$line" ] && continue
+  # Export the variable
+  export "$line"
+done < /etc/imapsync/${task_id}.env
 
 
 if [[ "$action" == "start" ]]; then


### PR DESCRIPTION
Previously, the sourcing of the environment variable in the `syncctl` script was not working correctly for the record spaces in the  exclude field.

This pull request fixes the issue by using a loop to export the variables from the file. Now, the environment variable is properly sourced and can be used in the script.

Refs NethServer/dev#6951