### PR TITLE
Fix unnecessary quotes around FOLDER_INBOX in syncctl script when only inbox  

### DIFF
--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -72,7 +72,8 @@ if [[ "${action}" == "start" ]]; then
         --passfile1 "/etc/imapsync/${task_id}.pwd" --port1 "${REMOTEPORT}" "${SECURITY}"  "$gmail" \
         --host2 "${MAIL_HOST}"  --user2 "${LOCALUSER}*vmail" \
         --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
-        "${FOLDER_INBOX}" --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
+        ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
+        # FOLDER_INBOX must not be enquoted NethServer/dev#7296
 
     # set the timestamp file to the current time
     touch -m -d "@${timestamp}" "/etc/imapsync/${task_id}.timestamp"
@@ -118,5 +119,6 @@ elif [[ "${action}" == "list-informations" ]]; then
     --passfile1 "/etc/imapsync/${task_id}.pwd" --port1 "${REMOTEPORT}" "${SECURITY}"  "$gmail" \
     --host2 "${MAIL_HOST}"  --user2 "${LOCALUSER}*vmail" \
     --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
-    "${FOLDER_INBOX}" --exclude '^Public$|^Shared$'"${exclude_regex}" --justfoldersizes --timeout1 10
+    ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" --justfoldersizes --timeout1 10
+    # FOLDER_INBOX must not be enquoted NethServer/dev#7296
 fi

--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -35,8 +35,7 @@ get_file_age_in_days() {
     local filename
     filename="/etc/imapsync/${task_id}.timestamp"
     local maxage
-    if [[ ! -f "$filename" ]] || [[ -n "${FOLDER_INBOX}" ]]; then
-        # either first sync or we only sync INBOX
+    if [[ ! -f "$filename" ]]; then
         maxage=""
     else
         # Get last access time in Unix timestamp
@@ -75,13 +74,9 @@ if [[ "${action}" == "start" ]]; then
         --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
         ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
         # FOLDER_INBOX must not be enquoted NethServer/dev#7296
-    if [[ -n "$FOLDER_INBOX" ]; then
-        # set the timestamp file to the current time
-        touch -m -d "@${timestamp}" "/etc/imapsync/${task_id}.timestamp"
-    else
-        # we only sync inbox
-        rm -f "/etc/imapsync/${task_id}.timestamp"
-    fi
+
+    # set the timestamp file to the current time
+    touch -m -d "@${timestamp}" "/etc/imapsync/${task_id}.timestamp"
 
 elif [[ "${action}" == "stop" ]];then
     if [[ -f "/etc/imapsync/${task_id}.pid" ]]; then

--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -35,7 +35,8 @@ get_file_age_in_days() {
     local filename
     filename="/etc/imapsync/${task_id}.timestamp"
     local maxage
-    if [[ ! -f "$filename" ]]; then
+    if [[ ! -f "$filename" ]] || [[ -n "${FOLDER_INBOX}" ]]; then
+        # either first sync or we only sync INBOX
         maxage=""
     else
         # Get last access time in Unix timestamp
@@ -74,9 +75,13 @@ if [[ "${action}" == "start" ]]; then
         --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
         ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
         # FOLDER_INBOX must not be enquoted NethServer/dev#7296
-
-    # set the timestamp file to the current time
-    touch -m -d "@${timestamp}" "/etc/imapsync/${task_id}.timestamp"
+    if [[ -n "$FOLDER_INBOX" ]; then
+        # set the timestamp file to the current time
+        touch -m -d "@${timestamp}" "/etc/imapsync/${task_id}.timestamp"
+    else
+        # we only sync inbox
+        rm -f "/etc/imapsync/${task_id}.timestamp"
+    fi
 
 elif [[ "${action}" == "stop" ]];then
     if [[ -f "/etc/imapsync/${task_id}.pid" ]]; then


### PR DESCRIPTION
- Remove unnecessary quotes around the FOLDER_INBOX variable to fix the  execution in the syncctl script when only inbox

Refs: https://github.com/NethServer/dev/issues/7296
