### PR TITLE
feat: run user's Sieve filter with imapsync

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -17,9 +17,10 @@ reponame="imapsync-binary"
 container=$(buildah from docker.io/library/alpine:3.21.3)
 buildah run "${container}" /bin/sh <<'EOF'
 set -e
-apk add --no-cache imapsync cronie
+apk add --no-cache imapsync cronie patch
 EOF
 buildah add "${container}" imapsync/ /
+buildah run --workingdir=/usr/bin/ "${container}" patch -p1 < imapsync-sievedelivery2.patch
 # Commit the image
 buildah commit --rm "${container}" "${repobase}/${reponame}"
 

--- a/imageroot/systemd/user/imapsync.service
+++ b/imageroot/systemd/user/imapsync.service
@@ -9,9 +9,6 @@
 #
 [Unit]
 Description=imapsync server
-#
-# Start the session of rootless modules after Redis
-#
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/imapsync-sievedelivery2.patch
+++ b/imapsync-sievedelivery2.patch
@@ -1,0 +1,64 @@
+commit 1e9719ded4ba267d4dd1c66556b44b6af38bbb93
+Author: Davide Principi <davide.principi@nethesis.it>
+Date:   Wed Mar 26 09:40:39 2025 +0100
+
+    feat(sievedelivery2): run FILTER SIEVE
+    
+    At the end of synchronization run FILTER SIEVE DELIVERY on transferred
+    messages. The FILTER=SIEVE capability is assumed to be present in host2.
+
+diff --git a/imapsync b/imapsync
+index a7f8f11..b2a9915 100755
+--- a/imapsync
++++ b/imapsync
+@@ -581,7 +581,10 @@ https://imapsync.lamiral.info/FAQ.d/FAQ.Gmail.txt
+  --idatefromheader   : Sets the internal dates on host2 as the same as the
+                        ones in "Date:" headers.
+ 
++=head2 OPTIONS/Sieve filters
+ 
++ --sievedelivery2    : Run FILTER SIEVE DELIVER (requires the FILTER capability
++                       on host2) for each message copied to host2.
+ 
+ =head2 OPTIONS/message selection
+ 
+@@ -3005,6 +3008,7 @@ FOLDER: foreach my $h1_fold ( @{ $sync->{h1_folders_wanted} } )
+ 	# Getting host2 headers, metada and delete2 stuff can be so long that host1 might be disconnected here
+         if ( ! reconnect_12_if_needed( $sync ) ) { last FOLDER ; }
+ 
++        my @h2_msgs_for_sieve ; # UIDs for FILTER SIEVE RUN
+         my @h1_msgs_to_delete ;
+         MESS: foreach my $m_id (@h1_hash_keys_sorted_by_uid) {
+                 abortifneeded( $sync ) ;
+@@ -3050,6 +3054,7 @@ FOLDER: foreach my $h1_fold ( @{ $sync->{h1_folders_wanted} } )
+                                 # same thing below on all total_bytes_max_reached!
+                                 last FOLDER ;
+                         }
++                        push @h2_msgs_for_sieve, $h2_msg ; # Store UID for Sieve processing
+                         next MESS;
+                 }
+                 else
+@@ -3152,7 +3157,14 @@ FOLDER: foreach my $h1_fold ( @{ $sync->{h1_folders_wanted} } )
+                 myprint( "Host1: Expunging folder $h1_fold $sync->{ dry_message }\n"  ) ;
+                 if ( ! $sync->{dry} ) { $sync->{ imap1 }->expunge(  ) } ;
+         }
+-        if ( $sync->{ expunge2 } ){
++        if ( $sync->{ sievedelivery2 } and @h2_msgs_for_sieve ) {
++                my $filter_sieve_cmd = "FILTER SIEVE DELIVERY UID " . $sync->{imap2}->Range(\@h2_msgs_for_sieve) ;
++                myprint( "Host2: Running $filter_sieve_cmd with EXPUNGE on $h2_fold $sync->{dry_message}\n"  ) ;
++                if ( ! $sync->{dry} ) {
++                        $sync->{imap2}->_imap_command($filter_sieve_cmd) ;
++                        $sync->{imap2}->expunge(  ) ;
++                }
++        } elsif ( $sync->{ expunge2 } ){
+                 myprint( "Host2: Expunging folder $h2_fold $sync->{ dry_message }\n"  ) ;
+                 if ( ! $sync->{dry} ) { $sync->{ imap2 }->expunge(  ) } ;
+         }
+@@ -22707,6 +22719,7 @@ sub get_options_cmd
+         'delete2folders!'     => \$mysync->{ delete2folders },
+         'delete2foldersonly=s'   => \$mysync->{ delete2foldersonly },
+         'delete2foldersbutnot=s' => \$mysync->{ delete2foldersbutnot },
++        'sievedelivery2!'    => \$mysync->{ sievedelivery2 },
+         'syncinternaldates!' => \$syncinternaldates,
+         'idatefromheader!'   => \$idatefromheader,
+         'syncacls!'          => \$mysync->{ syncacls },

--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -11,7 +11,7 @@
 # stop : stop the sync for the task_id
 # validation: validate the settings by trying to just login to imapsync and quit
 
-# shellcheck shell=dash
+# shellcheck shell=dash disable=SC3010
 
 set -e
 
@@ -73,7 +73,8 @@ if [[ "${action}" == "start" ]]; then
         --passfile1 "/etc/imapsync/${task_id}.pwd" --port1 "${REMOTEPORT}" "${SECURITY}"  "$gmail" \
         --host2 "${MAIL_HOST}"  --user2 "${LOCALUSER}*vmail" \
         --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
-        ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
+        ${FOLDER_INBOX} ${FOLDER_INBOX:+--sievedelivery2} \
+        --exclude '^Public$|^Shared$'"${exclude_regex}" > /proc/1/fd/1 2>&1
         # FOLDER_INBOX must not be enquoted NethServer/dev#7296
 
     # set the timestamp file to the current time


### PR DESCRIPTION
This PR reverts PR #41 and reimplements the same behavior with a patch for imapsync.

To ensure that the user's Sieve filter is not applied multiple times on the same INBOX message we limit the filter run on specific message UIDs. The exact UIDs is known to imapsync and the patch runs the FILTER SIEVE command directly from imapsync process.

Refs NethServer/dev#7230