### PR TITLE
fix(ui): missing Tasks page title

### DIFF
--- a/ui/src/views/Tasks.vue
+++ b/ui/src/views/Tasks.vue
@@ -237,6 +237,7 @@ import {
   IconService,
   TaskService,
   DateTimeService,
+  PageTitleService,
 } from "@nethserver/ns8-ui-lib";
 import to from "await-to-js";
 import ConfirmDeleteTask from "@/components/ConfirmDeleteTask";
@@ -260,6 +261,7 @@ export default {
     IconService,
     TaskService,
     DateTimeService,
+    PageTitleService,
   ],
   pageTitle() {
     return this.$t("tasks.title") + " - " + this.appName;


### PR DESCRIPTION
The Tasks page does not set the Browser tab title as other pages.

![image](https://github.com/user-attachments/assets/4640c55e-8a68-46ba-8380-ef90a0f5fdef)


Thanks to @mrmarkuz

Refs Nethserver/dev#7230