### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://imapsync.lamiral.info/#doc",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/imapsync.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-imapsync"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `ui/public/metadata.json` file to point to the latest official documentation for IMAPSync.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL14-R14): Updated the `documentation_url` from `https://imapsync.lamiral.info/#doc` to `https://docs.nethserver.org/projects/ns8/en/latest/imapsync.html` to ensure users are directed to the most relevant and up-to-date documentation.

https://github.com/NethServer/dev/issues/7399