### PR TITLE
fix: avoid silent crash on missing timestamp file at first sync

### DIFF
--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -50,7 +50,7 @@ print_log_excerpt() {
 get_file_age_in_days() {
     local filename
     filename="/etc/imapsync/${task_id}.timestamp"
-    prev_foldersync="$(cat ${filename} || :)"
+    prev_foldersync="$(cat ${filename} 2>/dev/null || true)"
 
     local maxage
     if [[ ! -f "$filename" ]] || [[ "${FOLDERSYNCHRONIZATION}" != "${prev_foldersync}" ]]; then


### PR DESCRIPTION
When a sync task is created for the first time, the .timestamp file does
not exist yet. With `set -e` active, the `cat` call in `get_file_age_in_days`
could cause the script to exit silently before imapsync even starts,
despite the `|| :` guard which is not reliable in ash subshell contexts.

Fixed by replacing `|| :` with `2>/dev/null || true`.

Fixes: first sync task always failing silently with "imapsync error: 143"
