### PR TITLE
Fix exclusion patterns for folder synchronization

### DIFF
--- a/imapsync/usr/local/bin/syncctl
+++ b/imapsync/usr/local/bin/syncctl
@@ -99,7 +99,7 @@ if [[ "${action}" == "start" ]]; then
         ${FOLDER_INBOX} \
         ${sieve_enabled:+--sievedelivery2} \
         ${sync_unseen:+--search1=UNSEEN --setflag1=Seen --noresyncflags} \
-        --exclude '^Public$|^Shared$'"${exclude_regex}" \
+        --exclude '^Shared(/.*)?$|^Public(/.*)?$'"${exclude_regex}" \
         >"/etc/imapsync/${task_id}.log" || \
     {
         exit_code=$?
@@ -153,6 +153,6 @@ elif [[ "${action}" == "list-informations" ]]; then
     --passfile1 "/etc/imapsync/${task_id}.pwd" --port1 "${REMOTEPORT}" "${SECURITY}"  "$gmail" \
     --host2 "${MAIL_HOST}"  --user2 "${LOCALUSER}*vmail" \
     --port2 143 --tls2 --passfile2 /etc/imapsync/vmail.pwd \
-    ${FOLDER_INBOX} --exclude '^Public$|^Shared$'"${exclude_regex}" --justfoldersizes --timeout1 10
+    ${FOLDER_INBOX} --exclude '^Shared(/.*)?$|^Public(/.*)?$'"${exclude_regex}" --justfoldersizes --timeout1 10
     # FOLDER_INBOX must not be enquoted NethServer/dev#7296
 fi

--- a/tests/20_imapsync.robot
+++ b/tests/20_imapsync.robot
@@ -115,7 +115,43 @@ Check the imap folder informations of u2
     Should Be True    7000 <= int(${ocfg['host2Sizes']}) < 8000 # the value can change
     Should Be True                 ${ocfg['status']}
 
-Check if imapsync can remove a task 
+Create Public and Shared folders with subfolders on u3
+    Execute Command    runagent -m ${MID} podman exec dovecot doveadm mailbox create -u u3 Public    return_rc=True
+    Execute Command    runagent -m ${MID} podman exec dovecot doveadm mailbox create -u u3 Public/Junk    return_rc=True
+    Execute Command    runagent -m ${MID} podman exec dovecot doveadm mailbox create -u u3 Shared    return_rc=True
+    Execute Command    runagent -m ${MID} podman exec dovecot doveadm mailbox create -u u3 Shared/estero    return_rc=True
+    Execute Command    runagent -m ${MID} podman exec dovecot doveadm mailbox create -u u3 Shared/estero/Archive/2020    return_rc=True
+
+Check if imapsync excludes Public and Shared subfolders
+    ${mail_server_uuid}    ${mail_server_ip}=    Evaluate    "${mail_modules_value}".split(",")
+    ${rc} =    Execute Command    api-cli run module/${imapsync_module_id}/create-task --data '{"cron": "5m","delete_local": false,"delete_remote": true,"delete_remote_older": 0,"exclude": "","foldersynchronization": "all","localuser": "u2","remotehostname": "${mail_server_ip}","remotepassword": "Nethesis,1234","remoteport": 143,"remoteusername": "u3","security": "tls","sieve_enabled": false,"task_id": "public_shared_test"}'
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+Verify Public and Shared folders were NOT synced to u2
+    ${success} =    Set Variable    False
+    FOR    ${i}    IN RANGE    10
+        ${dovecot_out}    ${dovecot_err}    ${dovecot_rc} =    Execute Command
+        ...    runagent -m ${MID} podman exec dovecot ls u2/Maildir | grep -c "^Public\|^Shared" || echo "0"
+        ...    return_rc=True    return_stdout=True    return_stderr=True
+        Should Be Equal As Integers    ${dovecot_rc}    0
+        ${dovecot_clean} =    Evaluate    str(${dovecot_out}).strip()
+        Log    Attempt ${i}: found=${dovecot_clean}
+        Run Keyword If    int(${dovecot_clean}) == 0    Set Test Variable    ${success}    True
+        Run Keyword If    ${success}    Exit For Loop
+        Sleep    1s
+    END
+    Should Be True    ${success}    Public and Shared folders should NOT be synced
+
+Verify no permission errors in imapsync logs
+    ${log_out}    ${log_err}    ${log_rc} =    Execute Command
+    ...    runagent -m ${MID} podman exec imapsync grep -i "NOPERM\|Could not select" /etc/imapsync/public_shared_test.log || echo "OK"
+    ...    return_rc=True    return_stdout=True    return_stderr=True
+    Should Be Equal As Integers    ${log_rc}    0
+    ${log_clean} =    Evaluate    str(${log_out}).strip()
+    Should Be Equal    ${log_clean}    OK    No permission errors should occur
+
+Check if imapsync can remove a task
     ${mail_server_uuid}    ${mail_server_ip}=    Evaluate    "${mail_modules_value}".split(",")
     ${rc} =    Execute Command    api-cli run module/${imapsync_module_id}/delete-task --data '{"localuser": "u2","task_id": "28ofi1"}'
     ...    return_rc=True  return_stdout=False

--- a/tests/20_imapsync.robot
+++ b/tests/20_imapsync.robot
@@ -132,12 +132,12 @@ Verify Public and Shared folders were NOT synced to u2
     ${success} =    Set Variable    False
     FOR    ${i}    IN RANGE    10
         ${dovecot_out}    ${dovecot_err}    ${dovecot_rc} =    Execute Command
-        ...    runagent -m ${MID} podman exec dovecot ls u2/Maildir | grep -c "^Public\|^Shared" || echo "0"
+        ...    runagent -m ${MID} bash -c "podman exec dovecot ls u2/Maildir 2>/dev/null | grep -E '^Public|^Shared' | wc -l"
         ...    return_rc=True    return_stdout=True    return_stderr=True
         Should Be Equal As Integers    ${dovecot_rc}    0
-        ${dovecot_clean} =    Evaluate    str(${dovecot_out}).strip()
+        ${dovecot_clean} =    Evaluate    "${dovecot_out}".strip()
         Log    Attempt ${i}: found=${dovecot_clean}
-        Run Keyword If    int(${dovecot_clean}) == 0    Set Test Variable    ${success}    True
+        Run Keyword If    '${dovecot_clean}' == '0'    Set Test Variable    ${success}    True
         Run Keyword If    ${success}    Exit For Loop
         Sleep    1s
     END
@@ -145,11 +145,16 @@ Verify Public and Shared folders were NOT synced to u2
 
 Verify no permission errors in imapsync logs
     ${log_out}    ${log_err}    ${log_rc} =    Execute Command
-    ...    runagent -m ${MID} podman exec imapsync grep -i "NOPERM\|Could not select" /etc/imapsync/public_shared_test.log || echo "OK"
+    ...    runagent -m ${MID} bash -c "podman exec imapsync grep -i 'NOPERM|Could not select' /etc/imapsync/public_shared_test.log && echo FOUND || echo OK"
     ...    return_rc=True    return_stdout=True    return_stderr=True
     Should Be Equal As Integers    ${log_rc}    0
-    ${log_clean} =    Evaluate    str(${log_out}).strip()
+    ${log_clean} =    Evaluate    "${log_out}".strip()
     Should Be Equal    ${log_clean}    OK    No permission errors should occur
+
+Delete public_shared_test task
+    ${rc} =    Execute Command    api-cli run module/${imapsync_module_id}/delete-task --data '{"localuser": "u2","task_id": "public_shared_test"}'
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
 
 Check if imapsync can remove a task
     ${mail_server_uuid}    ${mail_server_ip}=    Evaluate    "${mail_modules_value}".split(",")


### PR DESCRIPTION
Update exclusion patterns in the synchronization script to correctly handle folder paths for 'Public' and 'Shared' directories. This change ensures that the synchronization process excludes these folders as intended.

https://github.com/NethServer/dev/issues/8061